### PR TITLE
Fixes #1: Fix display issues with Maxim on mobile views

### DIFF
--- a/src/Components/Page/Top/Top.tsx
+++ b/src/Components/Page/Top/Top.tsx
@@ -2,7 +2,7 @@ import Blank from "../../UI/Blanks/Blank"
 import Footer from "../../UI/Footer"
 import Header from "../../UI/Header/Header"
 import LongLine from "../../UI/Lines/LongLine"
-import Quotes from "../../UI/Quotes"
+import Maxim from "../../UI/Maxim"
 import RecentCreation from "../Products/Genre/RecentCreation"
 import Profile from "./Profile"
 
@@ -11,7 +11,7 @@ const Top = () => {
         <>
             <Header/>
             <Blank />
-            <Quotes />
+            <Maxim />
             <Blank />
 
             <Profile />

--- a/src/Components/UI/Maxim.tsx
+++ b/src/Components/UI/Maxim.tsx
@@ -1,18 +1,18 @@
 import { useState, useEffect } from 'react'
 
-interface Quote {
+interface Maxim {
     content: string,
     author: string,
 }
 
-const Quotes = () => {
-    const [quote, setQuote] = useState<Quote | null>(null)
+const Maxim = () => {
+    const [maxim, setMaxim] = useState<Maxim | null>(null)
 
     useEffect(() => {
         fetch("https://api.quotable.io/random")
             .then(response => response.json())
-            .then((data: Quote) => {
-                setQuote(data)
+            .then((data: Maxim) => {
+                setMaxim(data)
             })
             .catch(e => console.error("Error fetching quote:", e))
     }, [])
@@ -20,16 +20,16 @@ const Quotes = () => {
     return (
         <>
         <div>
-            <h1 className='mx-auto w-144 max-md:w-100 max-sm:w-96 text-center text-5xl font-serif italic'>
+            <h1 className='mx-auto text-center text-5xl font-serif italic'>
                 Maxim
             </h1>
             <p className="text-sm text-center mt-3 mb-5 italic">
                 〜 本日の金言 〜
             </p>
-            {quote ? (
+            {maxim ? (
                 <blockquote className=' font-thin mx-auto w-144 max-md:w-100 max-sm:w-80 text-xl mt-5 text-center italic'>
-                    {quote.content}
-                    <footer className='flex justify-end mr-10'>{quote.author}</footer>
+                    {maxim.content}
+                    <footer className='flex justify-end mr-10'>{maxim.author}</footer>
                 </blockquote>
             ) : (
                 <p className=' font-thin mx-auto w-144 text-center text-2xl my-10'>Loading quote...</p>
@@ -40,4 +40,4 @@ const Quotes = () => {
     )
 }
 
-export default Quotes
+export default Maxim


### PR DESCRIPTION
Fixes #1: Fix display issues with Maxim on mobile views

スマホ表示時にTop画面の「Maxim」の文字がズレる問題が発生していた。
issuesで指摘された提案で修正対応を行っている。

なお、修正時に該当するコンポーネント名が「Quetes」となっていることに気づいたため、表示名に合わせて「Maxim」に名前を変更している。